### PR TITLE
Fix collection type expansion issues with varlena headers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ OBJS =  src/collection.o \
 		src/collection_subs.o \
 		src/collection_parse.o
 
-REGRESS = collection subscript iteration srf
+REGRESS = collection subscript iteration srf select
 REGRESS_OPTS = --inputdir=test --outputdir=test --load-extension=collection
 
 EXTRA_CLEAN = test/results/ test/regression.diffs test/regression.out pgcollection-$(EXTVERSION).zip

--- a/src/collection.c
+++ b/src/collection.c
@@ -224,6 +224,7 @@ DatumGetExpandedCollection(Datum d)
 	MemoryContext oldcxt;
 	int			location = 0;
 	int			i = 0;
+	struct varlena *attr;
 
 	if (VARATT_IS_EXTERNAL_EXPANDED(DatumGetPointer(d)))
 	{
@@ -236,7 +237,14 @@ DatumGetExpandedCollection(Datum d)
 
 	pgstat_report_wait_start(collection_we_expand);
 
-	fc = (FlatCollectionType *) DatumGetPointer(d);
+	/* Check whether toasted or not */
+	if (VARATT_IS_EXTENDED(DatumGetPointer(d)))
+	{
+		attr = PG_DETOAST_DATUM_COPY(d);
+		fc = (FlatCollectionType *) attr;
+	}
+	else
+		fc = (FlatCollectionType *) (DatumGetPointer(d));
 
 	/* Validate that the type exists */
 	lookup_type_cache(fc->value_type, 0);

--- a/test/expected/select.out
+++ b/test/expected/select.out
@@ -1,0 +1,142 @@
+CREATE TABLE select_collection(col_collection collection);
+INSERT INTO select_collection VALUES('{"value_type":"pg_catalog.text","entries":{"USA":"Washington", "UK":"London"}}');
+INSERT INTO select_collection VALUES('{"value_type":"pg_catalog.text","entries":{"India":"New Delhi"}}');
+INSERT INTO select_collection VALUES('{"entries":{"China":"Beijing"}}');
+INSERT INTO select_collection VALUES('{"value_type":"pg_catalog.text","entries":{"NULL":"NULL"}}');
+INSERT INTO select_collection VALUES('{"value_type":"pg_catalog.text","entries":{"Canada":"Ottawa"}}');
+INSERT INTO select_collection VALUES('{"value_type":"pg_catalog.text","entries":{"India":"New Delhi"}}');
+INSERT INTO select_collection VALUES('{"value_type":"pg_catalog.text","entries":{"Australia":"Canberra"}}');
+-- should throw error
+INSERT INTO select_collection VALUES('{"value_type":"pg_catalog.text","entries":{NULL:NULL}}');
+ERROR:  Invalid format
+LINE 1: INSERT INTO select_collection VALUES('{"value_type":"pg_cata...
+                                             ^
+SELECT * FROM select_collection;
+                                   col_collection                                    
+-------------------------------------------------------------------------------------
+ {"value_type": "pg_catalog.text", "entries": {"USA": "Washington", "UK": "London"}}
+ {"value_type": "pg_catalog.text", "entries": {"India": "New Delhi"}}
+ {"value_type": "pg_catalog.text", "entries": {"China": "Beijing"}}
+ {"value_type": "pg_catalog.text", "entries": {"NULL": "NULL"}}
+ {"value_type": "pg_catalog.text", "entries": {"Canada": "Ottawa"}}
+ {"value_type": "pg_catalog.text", "entries": {"India": "New Delhi"}}
+ {"value_type": "pg_catalog.text", "entries": {"Australia": "Canberra"}}
+(7 rows)
+
+SELECT sort(col_collection) FROM select_collection;
+                                        sort                                         
+-------------------------------------------------------------------------------------
+ {"value_type": "pg_catalog.text", "entries": {"UK": "London", "USA": "Washington"}}
+ {"value_type": "pg_catalog.text", "entries": {"India": "New Delhi"}}
+ {"value_type": "pg_catalog.text", "entries": {"China": "Beijing"}}
+ {"value_type": "pg_catalog.text", "entries": {"NULL": "NULL"}}
+ {"value_type": "pg_catalog.text", "entries": {"Canada": "Ottawa"}}
+ {"value_type": "pg_catalog.text", "entries": {"India": "New Delhi"}}
+ {"value_type": "pg_catalog.text", "entries": {"Australia": "Canberra"}}
+(7 rows)
+
+SELECT key(col_collection) FROM select_collection;
+    key    
+-----------
+ USA
+ India
+ China
+ NULL
+ Canada
+ India
+ Australia
+(7 rows)
+
+SELECT value(col_collection) FROM select_collection;
+   value    
+------------
+ Washington
+ New Delhi
+ Beijing
+ NULL
+ Ottawa
+ New Delhi
+ Canberra
+(7 rows)
+
+SELECT value_type(col_collection) FROM select_collection;
+ value_type 
+------------
+ text
+ text
+ text
+ text
+ text
+ text
+ text
+(7 rows)
+
+SELECT to_table(col_collection) FROM select_collection;
+       to_table       
+----------------------
+ (USA,Washington)
+ (UK,London)
+ (India,"New Delhi")
+ (China,Beijing)
+ (NULL,NULL)
+ (Canada,Ottawa)
+ (India,"New Delhi")
+ (Australia,Canberra)
+(8 rows)
+
+SELECT keys_to_table(col_collection) FROM select_collection;
+ keys_to_table 
+---------------
+ USA
+ UK
+ India
+ China
+ NULL
+ Canada
+ India
+ Australia
+(8 rows)
+
+SELECT values_to_table(col_collection) FROM select_collection;
+ values_to_table 
+-----------------
+ Washington
+ London
+ New Delhi
+ Beijing
+ NULL
+ Ottawa
+ New Delhi
+ Canberra
+(8 rows)
+
+SELECT COUNT(col_collection) FROM select_collection;
+ count 
+-------
+     2
+     1
+     1
+     1
+     1
+     1
+     1
+(7 rows)
+
+INSERT INTO select_collection VALUES('{"value_type":"pg_catalog.varchar","entries":{"Japan":"Tokyo"}}');
+INSERT INTO select_collection VALUES('{"value_type":"pg_catalog.char","entries":{"Canada":"Ottawa"}}');
+SELECT * FROM select_collection;
+                                   col_collection                                    
+-------------------------------------------------------------------------------------
+ {"value_type": "pg_catalog.text", "entries": {"USA": "Washington", "UK": "London"}}
+ {"value_type": "pg_catalog.text", "entries": {"India": "New Delhi"}}
+ {"value_type": "pg_catalog.text", "entries": {"China": "Beijing"}}
+ {"value_type": "pg_catalog.text", "entries": {"NULL": "NULL"}}
+ {"value_type": "pg_catalog.text", "entries": {"Canada": "Ottawa"}}
+ {"value_type": "pg_catalog.text", "entries": {"India": "New Delhi"}}
+ {"value_type": "pg_catalog.text", "entries": {"Australia": "Canberra"}}
+ {"value_type": "character varying", "entries": {"Japan": "Tokyo"}}
+ {"value_type": "pg_catalog.\"char\"", "entries": {"Canada": "O"}}
+(9 rows)
+
+DROP TABLE select_collection;
+

--- a/test/sql/select.sql
+++ b/test/sql/select.sql
@@ -1,0 +1,38 @@
+CREATE TABLE select_collection(col_collection collection);
+
+INSERT INTO select_collection VALUES('{"value_type":"pg_catalog.text","entries":{"USA":"Washington", "UK":"London"}}');
+INSERT INTO select_collection VALUES('{"value_type":"pg_catalog.text","entries":{"India":"New Delhi"}}');
+INSERT INTO select_collection VALUES('{"entries":{"China":"Beijing"}}');
+INSERT INTO select_collection VALUES('{"value_type":"pg_catalog.text","entries":{"NULL":"NULL"}}');
+INSERT INTO select_collection VALUES('{"value_type":"pg_catalog.text","entries":{"Canada":"Ottawa"}}');
+INSERT INTO select_collection VALUES('{"value_type":"pg_catalog.text","entries":{"India":"New Delhi"}}');
+INSERT INTO select_collection VALUES('{"value_type":"pg_catalog.text","entries":{"Australia":"Canberra"}}');
+
+-- should throw error
+INSERT INTO select_collection VALUES('{"value_type":"pg_catalog.text","entries":{NULL:NULL}}');
+
+SELECT * FROM select_collection;
+
+SELECT sort(col_collection) FROM select_collection;
+
+SELECT key(col_collection) FROM select_collection;
+
+SELECT value(col_collection) FROM select_collection;
+
+SELECT value_type(col_collection) FROM select_collection;
+
+SELECT to_table(col_collection) FROM select_collection;
+
+SELECT keys_to_table(col_collection) FROM select_collection;
+
+SELECT values_to_table(col_collection) FROM select_collection;
+
+SELECT COUNT(col_collection) FROM select_collection;
+
+INSERT INTO select_collection VALUES('{"value_type":"pg_catalog.varchar","entries":{"Japan":"Tokyo"}}');
+INSERT INTO select_collection VALUES('{"value_type":"pg_catalog.char","entries":{"Canada":"Ottawa"}}');
+
+SELECT * FROM select_collection;
+
+DROP TABLE select_collection;
+


### PR DESCRIPTION
Issue #8 : https://github.com/aws/pgcollection/issues/8

When retrieving stored collections, the varlena header was being misinterpreted due to PostgreSQL's internal header optimization (4-byte to 1-byte conversion). This caused misalignment of structure fields and incorrect interpretation of type OIDs.

Before fix:
- Stored with 4-byte header
- Retrieved with 1-byte header
- Resulted in invalid OID errors

After fix:
- Properly maintains 4-byte header alignment
- Correctly handles both regular and TOASTed values
- Maintains structure field alignment
- Includes proper memory management for detoasted data

Description of changes:
- Add proper varlena header handling with PG_DETOAST_DATUM_COPY
- Add conditional detoasting only for extended varlena types

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
