### PR TITLE
Fix logic of collection_get_flat_size to prevent memory overwriting

### DIFF
--- a/src/collection.c
+++ b/src/collection.c
@@ -92,9 +92,6 @@ collection_get_flat_size(ExpandedObjectHeader *eohptr)
 
 	Assert(colhdr->collection_magic == COLLECTION_MAGIC);
 
-	if (colhdr->flat_size)
-		return colhdr->flat_size;
-
 	pgstat_report_wait_start(collection_we_flatsize);
 
 	for (cur = colhdr->head; cur != NULL; cur = cur->hh.next)

--- a/test/expected/iteration.out
+++ b/test/expected/iteration.out
@@ -283,3 +283,15 @@ END
 $$;
 NOTICE:  Iteration test 16
 NOTICE:  value: <NULL>
+DO
+$$
+DECLARE
+  a collection;
+BEGIN
+  FOR i IN 1..1000 LOOP
+    a[i::text] := 'abc';
+  END LOOP;
+RAISE NOTICE 'Size of collection is %', length(a::text);
+END;
+$$;
+NOTICE:  Size of collection is 13939

--- a/test/sql/iteration.sql
+++ b/test/sql/iteration.sql
@@ -247,3 +247,14 @@ BEGIN
 END
 $$;
 
+DO
+$$
+DECLARE
+  a collection;
+BEGIN
+  FOR i IN 1..1000 LOOP
+    a[i::text] := 'abc';
+  END LOOP;
+RAISE NOTICE 'Size of collection is %', length(a::text);
+END;
+$$;

--- a/test/sql/select.sql
+++ b/test/sql/select.sql
@@ -35,4 +35,3 @@ INSERT INTO select_collection VALUES('{"value_type":"pg_catalog.char","entries":
 SELECT * FROM select_collection;
 
 DROP TABLE select_collection;
-


### PR DESCRIPTION
Description of changes:

This commit fixes logic of collection_get_flat_size to return correct size in order to avoid memory overwriting. Also, added tests to verify the behaviour.

Signed-off-by: Dipesh Dhameliya <dddhamel@amazon.com>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
