### PR TITLE
Fix use-after-free in collection delete operations 

### DIFF
--- a/src/collection_userfuncs.c
+++ b/src/collection_userfuncs.c
@@ -290,6 +290,8 @@ collection_delete(PG_FUNCTION_ARGS)
 			PG_RETURN_DATUM(EOHPGetRWDatum(&colhdr->hdr));
 		}
 
+		if (item == colhdr->current)
+			colhdr->current = item->hh.next;
 		HASH_DEL(colhdr->head, item);
 		pfree(item);
 


### PR DESCRIPTION
Fix use-after-free in collection delete operations and replace bulk allocation with individual allocation to fix crash

Issue #, if available:

https://github.com/aws/pgcollection/issues/25 and related https://github.com/aws/pgcollection/issues/33   =

Description of changes:

Fixed use-after-free in collection delete operations and replaced bulk allocation introduced in https://github.com/aws/pgcollection/commit/7ad27e8094dda31981858c114286d64459681da3 with individual allocation to avoid crash 

also fixed regression test

```
echo "# +++ regress install-check in  +++" && /usr/local/pgsql/lib/pgxs/src/makefiles/../../src/test/regress/pg_regress --inputdir=./ --bindir='/usr/local/pgsql/bin'    --inputdir=test --outputdir=test --load-extension=collection --dbname=contrib_regression collection subscript iteration srf select
# +++ regress install-check in  +++
# using postmaster on /tmp, default port
ok 1         - collection                                 25 ms
ok 2         - subscript                                  12 ms
ok 3         - iteration                                  10 ms
ok 4         - srf                                        15 ms
ok 5         - select                                     20 ms
1..5
# All 5 tests passed.
```

and issue metioned in https://github.com/aws/pgcollection/issues/25 and related  resolved 

```
postgres=# DO
postgres-# $$
postgres$# DECLARE
postgres$#   t_1  collection;
postgres$# BEGIN
postgres$#   t_1 := '{"value_type":"pg_catalog.text","entries":{"A":"A","B":"B","C":"C"}}'::collection;
postgres$#   t_1 := delete(t_1, 'A');
postgres$#   t_1 := add(t_1,'D','D');
postgres$#   raise notice '%', key(t_1);
postgres$# END
postgres$# $$;
NOTICE:  B
DO
```

```
postgres=# DO $$
postgres$# DECLARE
postgres$#   arr_instance collection('collection');
postgres$# BEGIN
postgres$# 
postgres$#   -- Initialize: A -> AA := 1
postgres$#   arr_instance := add(arr_instance, 'A', add(NULL::collection, 'AA', 1::int));
postgres$# 
postgres$#   FOR i IN 1..10 LOOP
postgres$#     -- Update: A -> AB := 1
postgres$#     RAISE NOTICE 'Attempt: %', i;
postgres$#     arr_instance := add(arr_instance, 'A', add(find(arr_instance, 'A', NULL::collection), 'AB', 1::int));
postgres$#   END LOOP;
postgres$# 
postgres$# END; $$;
NOTICE:  Attempt: 1
NOTICE:  Attempt: 2
NOTICE:  Attempt: 3
NOTICE:  Attempt: 4
NOTICE:  Attempt: 5
NOTICE:  Attempt: 6
NOTICE:  Attempt: 7
NOTICE:  Attempt: 8
NOTICE:  Attempt: 9
NOTICE:  Attempt: 10
DO
```