### PR TITLE
fix Collection JSON Parsing Allows Duplicate Keys

### DIFF
--- a/src/collection.c
+++ b/src/collection.c
@@ -276,6 +276,7 @@ DatumGetExpandedCollection(Datum d)
 		size_t		value_len;
 		char	   *key;
 		collection *item;
+		collection *replaced_item;
 
 		memcpy((unsigned char *) &key_len, fc->values + location, sizeof(int16));
 		location += sizeof(int16);
@@ -315,7 +316,15 @@ DatumGetExpandedCollection(Datum d)
 		}
 		location += value_len;
 
-		HASH_ADD(hh, colhdr->head, key[0], key_len, item);
+		HASH_REPLACE(hh, colhdr->head, key[0], key_len, item, replaced_item);
+		if (replaced_item)
+		{
+			if (replaced_item->key)
+				pfree(replaced_item->key);
+			if (replaced_item->isnull == false && replaced_item->value)
+				pfree(DatumGetPointer(replaced_item->value));
+			pfree(replaced_item);
+		}
 
 		if (i == 0)
 		{

--- a/src/collection_subs.c
+++ b/src/collection_subs.c
@@ -280,6 +280,14 @@ collection_subscript_assign(ExprState *state,
 	}
 
 	HASH_REPLACE(hh, colhdr->head, key[0], strlen(key), item, replaced_item);
+	if (replaced_item)
+	{
+		if (replaced_item->key)
+			pfree(replaced_item->key);
+		if (replaced_item->isnull == false && replaced_item->value)
+			pfree(DatumGetPointer(replaced_item->value));
+		pfree(replaced_item);
+	}
 
 	if (colhdr->current == NULL)
 		colhdr->current = colhdr->head;


### PR DESCRIPTION
Issue #, if available:
https://github.com/aws/pgcollection/issues/38

Description of changes:
Replaced HASH_ADD with HASH_REPLACE in collection operations to properly handle duplicate keys
Also added memory deallocation for replaced items and ensure current poiniter always points to valid memory

```
postgres=# DO
$$
DECLARE
  t_1 collection;
BEGIN
  t_1 := '{"value_type":"pg_catalog.text","entries":{"A":"1","A":"2"}}'::collection;
  raise notice '%',t_1;
  raise notice '%',t_1['A'];
  t_1 := delete(t_1,'A');
  raise notice '%',t_1['A'];
END
$$;
NOTICE:  {"value_type": "pg_catalog.text", "entries": {"A": "2"}}
NOTICE:  2
ERROR:  key "A" not found
CONTEXT:  PL/pgSQL function inline_code_block line 9 at RAISE
```

```
lection subscript iteration srf select
# +++ regress install-check in  +++
# using postmaster on /tmp, default port
ok 1         - collection                                 23 ms
ok 2         - subscript                                  12 ms
ok 3         - iteration                                   9 ms
ok 4         - srf                                        14 ms
ok 5         - select                                     18 ms
1..5
# All 5 tests passed.

```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
I confirmed 