### PR TITLE
fix inconsistent JSON parsing behavior

### DIFF
--- a/src/collection_parse.c
+++ b/src/collection_parse.c
@@ -32,6 +32,7 @@ typedef enum
 	EXPECT_TOPLEVEL_FIELD,
 	EXPECT_VALUE_TYPE,
 	EXPECT_ENTRIES,
+	EXPECT_ENTRIES_OBJECT,
 	EXPECT_EOF,
 }			JsonCollectionSemanticState;
 
@@ -191,6 +192,7 @@ json_collection_object_start(void *state)
 			break;
 
 		case EXPECT_ENTRIES:
+			parse->state = EXPECT_ENTRIES_OBJECT;
 			break;
 
 		default:
@@ -212,7 +214,7 @@ json_collection_object_end(void *state)
 			parse->state = EXPECT_EOF;
 			break;
 
-		case EXPECT_ENTRIES:
+		case EXPECT_ENTRIES_OBJECT:
 			parse->state = EXPECT_TOPLEVEL_END;
 			break;
 
@@ -258,7 +260,7 @@ json_collection_object_field_start(void *state, char *fname, bool isnull)
 			elog(ERROR, "unrecognized top-level field");
 			break;
 
-		case EXPECT_ENTRIES:
+		case EXPECT_ENTRIES_OBJECT:
 			key = palloc0(strlen(fname) + 1);
 			strcpy(key, fname);
 			parse->keys = lappend(parse->keys, key);
@@ -288,6 +290,10 @@ json_collection_scalar(void *state, char *token, JsonTokenType tokentype)
 			break;
 
 		case EXPECT_ENTRIES:
+			elog(ERROR, "\"entries\" field must be a JSON object, not a scalar value");
+			break;
+
+		case EXPECT_ENTRIES_OBJECT:
 			parse->values = lappend(parse->values, token);
 			break;
 


### PR DESCRIPTION
Issue #, if available:
https://github.com/aws/pgcollection/issues/35
Description of changes:
Add new parser state EXPECT_ENTRIES_OBJECT to distinguish between entries field and entries object content so that rejects malformed JSON where "entries" is not an object

```
postgres=# SELECT '{"value_type":"pg_catalog.text","entries":"A","B":"B","C":{}}'::collection;
ERROR:  "entries" field must be a JSON object, not a scalar value
LINE 1: SELECT '{"value_type":"pg_catalog.text","entries":"A","B":"B...
               ^
postgres=# 
postgres=# SELECT '{"value_type": "pg_catalog.text", "entries": {"B": "A", "C": "B"}}'::collection;
                             collection                             
--------------------------------------------------------------------
 {"value_type": "pg_catalog.text", "entries": {"B": "A", "C": "B"}}
(1 row)
```

regression passed 

```
dir=test --outputdir=test --load-extension=collection --dbname=contrib_regression collection subscript iteration srf select
# +++ regress install-check in  +++
# using postmaster on /tmp, default port
ok 1         - collection                                 25 ms
ok 2         - subscript                                  13 ms
ok 3         - iteration                                  10 ms
ok 4         - srf                                        14 ms
ok 5         - select                                     19 ms
1..5
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
I confirmed