### PR TITLE
Put type modifier between parentheses and quotes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ OBJS = src/collection.o \
 		src/icollection_subs.o \
 		src/icollection_parse.o
 
-REGRESS = basics subscript iteration srf persistence inout_params mixed_types stress edge_cases array_interop
+REGRESS = basics subscript iteration srf persistence inout_params mixed_types stress edge_cases array_interop typemod
 REGRESS_OPTS = --inputdir=test --outputdir=test --load-extension=collection
 
 EXTRA_CLEAN = test/results/ test/regression.diffs test/regression.out \

--- a/src/collection_common.c
+++ b/src/collection_common.c
@@ -105,12 +105,9 @@ char *
 collection_typmodout_common(Oid typmod)
 {
 	char       *typeName;
-	char	   *res;
 
 	typeName = DatumGetCString(DirectFunctionCall1(regtypeout, typmod));
-	res = (char*)palloc(strlen(typeName) + 5);
-	sprintf(res, "('%s')", typeName);
-	return res;
+	return psprintf("('%s')", typeName);
 }
 
 /*

--- a/src/collection_common.c
+++ b/src/collection_common.c
@@ -104,7 +104,13 @@ collection_typmodin_common(ArrayType *ta, const char *type_name)
 char *
 collection_typmodout_common(Oid typmod)
 {
-	return DatumGetCString(DirectFunctionCall1(regtypeout, typmod));
+	char       *typeName;
+	char	   *res;
+
+	typeName = DatumGetCString(DirectFunctionCall1(regtypeout, typmod));
+	res = (char*)palloc(strlen(typeName) + 5);
+	sprintf(res, "('%s')", typeName);
+	return res;
 }
 
 /*

--- a/test/expected/typemod.out
+++ b/test/expected/typemod.out
@@ -1,0 +1,18 @@
+create schema typemodtest;
+create type typemodtest.my_rec as (
+	coll_no_typemod              collection,
+	coll_typemod_int             collection('int'),
+	icoll_no_typemod             icollection,
+	icollection_typemod_varchar  icollection('varchar')
+);
+\d typemodtest.my_rec
+                               Composite type "typemodtest.my_rec"
+           Column            |               Type               | Collation | Nullable | Default 
+-----------------------------+----------------------------------+-----------+----------+---------
+ coll_no_typemod             | collection                       |           |          | 
+ coll_typemod_int            | collection('integer')            |           |          | 
+ icoll_no_typemod            | icollection                      |           |          | 
+ icollection_typemod_varchar | icollection('character varying') |           |          | 
+
+drop schema typemodtest cascade;
+NOTICE:  drop cascades to type typemodtest.my_rec

--- a/test/sql/typemod.sql
+++ b/test/sql/typemod.sql
@@ -1,0 +1,9 @@
+create schema typemodtest;
+create type typemodtest.my_rec as (
+	coll_no_typemod              collection,
+	coll_typemod_int             collection('int'),
+	icoll_no_typemod             icollection,
+	icollection_typemod_varchar  icollection('varchar')
+);
+\d typemodtest.my_rec
+drop schema typemodtest cascade;


### PR DESCRIPTION
The type modifier (if any) for a collection or icollection is specified as the text representation of a data type, like:
    collection('text')
But when displaying the type, it showed as collectiontext instead of collection('text').

Issue #, if available:

Description of changes:

With definitions:
```
postgres=# create schema typemodtest;
CREATE SCHEMA
postgres=# create type typemodtest.my_rec as (
        coll_no_typemod              collection,
        coll_typemod_int             collection('int'),
        icoll_no_typemod             icollection,
        icollection_typemod_varchar  icollection('varchar')
);
CREATE TYPE
```
the type definition shows as:
```
postgres=# \d typemodtest.my_rec
                             Composite type "typemodtest.my_rec"
           Column            |             Type             | Collation | Nullable | Default 
-----------------------------+------------------------------+-----------+----------+---------
 coll_no_typemod             | collection                   |           |          | 
 coll_typemod_int            | collectioninteger            |           |          | 
 icoll_no_typemod            | icollection                  |           |          | 
 icollection_typemod_varchar | icollectioncharacter varying |           |          | 

```
but should show as:
```
postgres=# \d typemodtest.my_rec
                               Composite type "typemodtest.my_rec"
           Column            |               Type               | Collation | Nullable | Default 
-----------------------------+----------------------------------+-----------+----------+---------
 coll_no_typemod             | collection                       |           |          | 
 coll_typemod_int            | collection('integer')            |           |          | 
 icoll_no_typemod            | icollection                      |           |          | 
 icollection_typemod_varchar | icollection('character varying') |           |          | 

```
That is what this pull request is about.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
