### PR TITLE
Put type modifier between parentheses and quotes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ OBJS = src/collection.o \
 		src/icollection_subs.o \
 		src/icollection_parse.o
 
-REGRESS = basics subscript iteration srf persistence inout_params mixed_types stress edge_cases array_interop
+REGRESS = basics subscript iteration srf persistence inout_params mixed_types stress edge_cases array_interop typemod
 REGRESS_OPTS = --inputdir=test --outputdir=test --load-extension=collection
 
 EXTRA_CLEAN = test/results/ test/regression.diffs test/regression.out \

--- a/src/collection_common.c
+++ b/src/collection_common.c
@@ -105,12 +105,9 @@ char *
 collection_typmodout_common(Oid typmod)
 {
 	char       *typeName;
-	char	   *res;
 
 	typeName = DatumGetCString(DirectFunctionCall1(regtypeout, typmod));
-	res = (char*)palloc(strlen(typeName) + 5);
-	sprintf(res, "('%s')", typeName);
-	return res;
+	return psprintf("('%s')", typeName);
 }
 
 /*

--- a/src/collection_common.c
+++ b/src/collection_common.c
@@ -104,7 +104,13 @@ collection_typmodin_common(ArrayType *ta, const char *type_name)
 char *
 collection_typmodout_common(Oid typmod)
 {
-	return DatumGetCString(DirectFunctionCall1(regtypeout, typmod));
+	char       *typeName;
+	char	   *res;
+
+	typeName = DatumGetCString(DirectFunctionCall1(regtypeout, typmod));
+	res = (char*)palloc(strlen(typeName) + 5);
+	sprintf(res, "('%s')", typeName);
+	return res;
 }
 
 /*

--- a/src/collection_common.c
+++ b/src/collection_common.c
@@ -104,10 +104,7 @@ collection_typmodin_common(ArrayType *ta, const char *type_name)
 char *
 collection_typmodout_common(Oid typmod)
 {
-	char       *typeName;
-
-	typeName = DatumGetCString(DirectFunctionCall1(regtypeout, typmod));
-	return psprintf("('%s')", typeName);
+	return psprintf("('%s')", DatumGetCString(DirectFunctionCall1(regtypeout, typmod)));
 }
 
 /*

--- a/test/expected/typemod.out
+++ b/test/expected/typemod.out
@@ -1,0 +1,18 @@
+create schema typemodtest;
+create type typemodtest.my_rec as (
+	coll_no_typemod              collection,
+	coll_typemod_int             collection('int'),
+	icoll_no_typemod             icollection,
+	icollection_typemod_varchar  icollection('varchar')
+);
+\d typemodtest.my_rec
+                               Composite type "typemodtest.my_rec"
+           Column            |               Type               | Collation | Nullable | Default 
+-----------------------------+----------------------------------+-----------+----------+---------
+ coll_no_typemod             | collection                       |           |          | 
+ coll_typemod_int            | collection('integer')            |           |          | 
+ icoll_no_typemod            | icollection                      |           |          | 
+ icollection_typemod_varchar | icollection('character varying') |           |          | 
+
+drop schema typemodtest cascade;
+NOTICE:  drop cascades to type typemodtest.my_rec

--- a/test/sql/typemod.sql
+++ b/test/sql/typemod.sql
@@ -1,0 +1,9 @@
+create schema typemodtest;
+create type typemodtest.my_rec as (
+	coll_no_typemod              collection,
+	coll_typemod_int             collection('int'),
+	icoll_no_typemod             icollection,
+	icollection_typemod_varchar  icollection('varchar')
+);
+\d typemodtest.my_rec
+drop schema typemodtest cascade;


### PR DESCRIPTION
Issue #, if available:

Description of changes:

See my previous pull request: [https://github.com/aws/pgcollection/pull/44](https://github.com/aws/pgcollection/pull/44) but now with palloc() and sprintf() combined into psprintf().

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
